### PR TITLE
Prepend canvas instead of adding it before the div.

### DIFF
--- a/public_html/js/9patch.js
+++ b/public_html/js/9patch.js
@@ -106,11 +106,12 @@ $(window).load(function() {
 			}
 			
 			var position = $(this).position();
-			$(dCanvas).css('left',     position.left);
-			$(dCanvas).css('top',      position.top);
+			$(dCanvas).css('z-index',  -1);
+			$(dCanvas).css('left',     0);
+			$(dCanvas).css('top',      0);
 			$(dCanvas).css('position', 'absolute');
 			
-			$(this).before(dCanvas);
+			$(this).prepend(dCanvas);
 			
 		}
 	});


### PR DESCRIPTION
Modified javascript to prepend canvas instead of adding it before the div, so when the div is hidden the background is hidden as well.
